### PR TITLE
ci: stop writing Decision task to index

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -169,12 +169,7 @@ tasks:
                                   then:
                                       kind: cron-task
                       routes:
-                          $flatten:
-                              - checks
-                              - $if: 'tasks_for == "github-push"'
-                                then:
-                                    - "index.${trustDomain}.v2.${project}.revision.${head_sha}.taskgraph.decision"
-                                else: []
+                          - checks
                       scopes:
                           $if: 'tasks_for == "github-push"'
                           then:


### PR DESCRIPTION
The Decision task no longer has scopes to write here for security reasons. See: https://bugzilla.mozilla.org/show_bug.cgi?id=2058191